### PR TITLE
도메인 설계하기

### DIFF
--- a/corporation/src/main/java/inflearn/com/corporation/member/entity/Member.java
+++ b/corporation/src/main/java/inflearn/com/corporation/member/entity/Member.java
@@ -1,0 +1,79 @@
+package inflearn.com.corporation.member.entity;
+
+import inflearn.com.corporation.member.entity.type.Role;
+import inflearn.com.corporation.team.entity.Team;
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
+
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Column(nullable = false)
+    private LocalDate birthday;
+
+    @Column(nullable = false)
+    private LocalDate workStartDate;
+
+    protected Member() {
+    }
+
+    public Member(String name, Team team, Role role, LocalDate birthday, LocalDate workStartDate) {
+        this.name = name;
+        changeTeam(team);
+        this.role = role;
+        this.birthday = birthday;
+        this.workStartDate = workStartDate;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Team getTeam() {
+        return team;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    public LocalDate getWorkStartDate() {
+        return workStartDate;
+    }
+
+    public void changeTeam(Team team) {
+        if (this.team != null) { // 이전 팀이 설정되어 있으면
+            this.team.getMembers().remove(this); // 이전 팀에서 해당 멤버 제거
+        }
+        this.team = team; // 새로운 팀으로 연관 관계 설정
+        if (team != null) { // 새로운 팀이 null 이 아니라면
+            team.getMembers().add(this); // 새로운 팀에 해당 멤버 추가
+        }
+    }
+}

--- a/corporation/src/main/java/inflearn/com/corporation/member/entity/type/Role.java
+++ b/corporation/src/main/java/inflearn/com/corporation/member/entity/type/Role.java
@@ -1,0 +1,5 @@
+package inflearn.com.corporation.member.entity.type;
+
+public enum Role {
+    MANAGER, MEMBER
+}

--- a/corporation/src/main/java/inflearn/com/corporation/team/entity/Team.java
+++ b/corporation/src/main/java/inflearn/com/corporation/team/entity/Team.java
@@ -1,0 +1,68 @@
+package inflearn.com.corporation.team.entity;
+
+import inflearn.com.corporation.member.entity.Member;
+import inflearn.com.corporation.member.entity.type.Role;
+import jakarta.persistence.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Team {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "team_id")
+    private Long id;
+    
+    @Column(nullable = false)
+    private String name;
+
+    private String manager;
+
+    @OneToMany(mappedBy = "team")
+    List<Member> members = new ArrayList<>();
+
+    private Long memberCount;
+
+    protected Team() {}
+
+    public Team(String name) {
+        this.name = name;
+        this.memberCount = 0L;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getManager() {
+        return manager;
+    }
+
+    public List<Member> getMembers() {
+        return members;
+    }
+
+    public Long getMemberCount() {
+        return memberCount;
+    }
+
+    public boolean hasManager() {
+        return members.stream().anyMatch(member -> member.getRole() == Role.MANAGER);
+    }
+
+    public void setManagerName(String manager) {
+        this.manager = manager;
+    }
+
+    public void addMember(Member member) {
+        members.add(member);
+        memberCount++;
+    }
+
+}


### PR DESCRIPTION
### 1. ENUM 타입 활용
역할을 `ENUM` 타입으로 `MANAGER, MEMBER` 두 타입을 받도록 설정하고, 정수가 아닌 `@Enumerated(EnumType.STRING)` 문자열 그대로 저장을 합니다.

### 2. 연관 관계의 주인은 회원 엔티티
```
@ManyToOne(fetch = FetchType.LAZY)
@JoinColumn(name = "team_id")
private Team team;
```
회원 엔티티의 `team` 필드를 통해 팀 엔티티의 기본 키인 `team_id`를 참조하도록 설정합니다.
- `@JoinColumn` 은 JPA가 테이블에 외래 키를 컬럼을 매핑하는 방법을 설정하는 애노테이션입니다. 대신에 이런 설정들이 없으면 JPA가 제공하는 기본 설정으로 외래 키 컬럼 이름을 매핑합니다.
주인은 `mappedBy` 속성을 사용하지 않습니다.


### 3. 연관 관계 편의 메서드 사용하기
```
    public void changeTeam(Team team) {
        if (this.team != null) { // 이전 팀이 설정되어 있으면
            this.team.getMembers().remove(this); // 이전 팀에서 해당 멤버 제거
        }
        this.team = team; // 새로운 팀으로 연관 관계 설정
        if (team != null) { // 새로운 팀이 null 이 아니라면
            team.getMembers().add(this); // 새로운 팀에 해당 멤버 추가
        }
```
`changeTeam(Team team)` 메서드는 회원의 팀을 변경하거나 회원 등록과 함께 팀의 정보를 입력할 때 사용을 목적으로 구현한 연관 관계 편의 메서드 입니다. 주요 동작은 다음과 같습니다.
1. 회원이 이미 팀에 속한 경우 제거합니다.
2. 그리고 회원은 새로운 팀을 설정합니다.
3. 새로운 팀이 `null`이 아니면 팀 엔티티의 `List<Member>` 에 회원을 추가합니다.

마지막으로 회원 생성자로부터 changeTeam 메서드를 사용하여 회원 등록할 때 팀 엔티티를 참조 받을 수 있습니다.


```
    public Member(String name, Team team, Role role, LocalDate birthday, LocalDate workStartDate) {
        this.name = name;
        changeTeam(team);
        this.role = role;
        this.birthday = birthday;
        this.workStartDate = workStartDate;
    }
```

연관관계 메서드가 중요한 이유는 테이블과 객체 관점이 다르기 때문에 놓치는 경우가 많습니다.
- 객체는 연관 관계가 있는 회원과 팀 모두 참조할 수 있는 객체가 존재하고 있어야 서로를 참조할 수 있습니다.
 - 테이블은 외래 키 하나만으로 두 객체가 서로를 참조가 가능합니다.
따라서 테이블 관점에서는 회원과 팀 중에서 한 곳만 외래 키가 존재하기 때문에, 객체에서도 한 곳에서만 참조 값을 대입하면 들어갈 것으로 잘못된 예상할 수 있습니다.
반드시 객체에서 서로 참조가 정상적으로 동작하기 위해서는 두 군데에 모두 참조 값을 대입해야 합니다.

지금처럼 두 객체 사이에 한 곳에서만 연관 관계 편의 메서드를 생성하여, 논리적으로 넣는 곳에서 값을 넣을 때 모든 처리를 수행합니다.


&nbsp;  
 
---

&nbsp;

### 4. 연관 관계의 주인이 아닌 팀 엔티티

```
@OneToMany(mappedBy = "team")
List<Member> members = new ArrayList<>();
```

연관관계의 주인은 테이블에 외래 키가 있는 곳으로 정해야 합니다. 회원 테이블이 외래 키를 가지고 있으므로 `Member.team`이 주인이 됩니다.
주인이 아니면 `mappedBy` 속성을 사용해서 속성의 값으로 `team`은 연관관계의 주인인 회원 엔티티의 `team` 필드를 말합니다.
참고로, 데이터베이스 테이블의 다대일, 일대다 관계에서는 항상 다 쪽이 외래 키를 가집니다. 다 쪽인 `@ManyToOne` 은 항상 연관 관계의 주인이 되므로 `mappedBy` 를 설정할 수 없습니다. 따라서 주인인 `@ManyToOne`에는 `mappedBy` 속성이 없습니다.


### 5. 팀 등록 시점

```
    public Team(String name) {
        this.name = name;
        this.memberCount = 0L;
    }
```
팀 등록 시점에 회원은 없기 때문에 0명입니다.



### 6. 매니저 유무 확인하기

```
    public boolean hasManager() {
        return members.stream().anyMatch(member -> member.getRole() == Role.MANAGER);
    }
```
회원의 `role`이 `MANAGER` 인 유무를 `boolean`으로 반환합니다.

나머지는 코드로 이해가 충분히 가능합니다.