### PR TITLE
[2단계] 출퇴근 엔티티 생성하기

### DIFF
--- a/corporation/src/main/java/inflearn/com/corporation/commute/entity/Commute.java
+++ b/corporation/src/main/java/inflearn/com/corporation/commute/entity/Commute.java
@@ -1,0 +1,61 @@
+package inflearn.com.corporation.commute.entity;
+
+import inflearn.com.corporation.member.entity.Member;
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+public class Commute {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "commute_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+    private LocalDate date;
+    private LocalTime startedAt;
+    private LocalTime endedAt;
+
+    protected Commute() {
+    }
+
+    public Commute(Member member) {
+        this.member = member;
+        this.date = LocalDate.now();
+        this.startedAt = LocalTime.now().withNano(0);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public LocalTime getStartedAt() {
+        return startedAt;
+    }
+
+    public LocalTime getEndedAt() {
+        return endedAt;
+    }
+
+    // 퇴근 처리
+    public void endCommute(LocalTime endedAt) {
+        if (this.endedAt != null) {
+            throw new IllegalStateException("이미 퇴근 처리되었습니다.");
+        }
+        this.endedAt = endedAt;
+    }
+
+}

--- a/corporation/src/main/java/inflearn/com/corporation/member/entity/Member.java
+++ b/corporation/src/main/java/inflearn/com/corporation/member/entity/Member.java
@@ -1,10 +1,13 @@
 package inflearn.com.corporation.member.entity;
 
+import inflearn.com.corporation.commute.entity.Commute;
 import inflearn.com.corporation.member.entity.type.Role;
 import inflearn.com.corporation.team.entity.Team;
 import jakarta.persistence.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 public class Member {
@@ -21,7 +24,6 @@ public class Member {
     @JoinColumn(name = "team_id")
     private Team team;
 
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
@@ -31,6 +33,9 @@ public class Member {
 
     @Column(nullable = false)
     private LocalDate workStartDate;
+
+    @OneToMany(mappedBy = "member")
+    List<Commute> commutes = new ArrayList<>();
 
     protected Member() {
     }
@@ -65,6 +70,10 @@ public class Member {
 
     public LocalDate getWorkStartDate() {
         return workStartDate;
+    }
+
+    public List<Commute> getCommutes() {
+        return commutes;
     }
 
     public void changeTeam(Team team) {


### PR DESCRIPTION
새롭게 생성된 `Commute` 엔티티는 다음과 같은 컬럼을 가지고 있습니다.
- `id`: `Commute` 엔티티의 고유 식별 번호
- `member`: `Member` 엔티티의 외래 키에 해당
- `date` : 출근 기록 날짜
- `startedAt` : 출근 시간
- `endedAt` : 퇴근 시간

`Commute` 엔티티는 `Member` 엔티티와 다대일 연관 관계를 가지며 주인에 해당됩니다. 테이블이 생성되면 `Commute` 테이블에는 `member_id` 외래 키가 생성되고, `member_id` 를 기준으로 직원의 출퇴근을 처리할 수 있습니다.
연관 관계의 주인은 외래 키가 있는 곳으로 정한다는 것을 기억하고, 두 테이블의 `id` 를 기준으로 JPA 에 의해 자동적으로 연관 관계를 갖게 됩니다.  `@JoinColumn` 에 의해서가 절대 아닌, 생성되는 외래 키 이름을 지정한 것 뿐이라는 점을 참고합니다. `referencedColumnName` 속성을 참고하기 바랍니다.

```
    public Commute(Member member) {
        this.member = member;
        this.date = LocalDate.now();
        this.startedAt = LocalTime.now().withNano(0);
    }
```
출퇴근을 하기 위해서 `Member` 를 받아야 합니다.
따라서 직원 등록이 안되어 있다면 출퇴근을 할 수 없습니다.
- 출근하는 경우는 `시/분/초`형식의 `LocalTime` 타입으로 현재 시각이 자동으로 생성됩니다. 날짜 정보는 `년-월-일` 형식의 `LocalDate` 타입으로 오늘 날짜로 자동으로 생성됩니다.

```
    // 퇴근 처리
    public void endCommute(LocalTime endedAt) {
        if (this.endedAt != null) {
            throw new IllegalStateException("이미 퇴근 처리되었습니다.");
        }
        this.endedAt = endedAt;
    }
```
`endedAt` 컬럼에 정보가 이미 존재하는 경우에는 이미 퇴근 처리가 된 상태입니다. `endedAt` 컬럼 안에 `null` 이라면 입력받은 퇴근 시간 `endedAt` 을 저장합니다.
