### PR TITLE
오타 수정하기

### DIFF
--- a/corporation/src/main/java/inflearn/com/corporation/member/repository/MemberRepository.java
+++ b/corporation/src/main/java/inflearn/com/corporation/member/repository/MemberRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
+    Optional<Member> findMemberById(Long memberId);
 }


### PR DESCRIPTION
    Optional<Member> findMemberById(Long memberId);

위의 메서드가 왜 사라진 건지 모르겠다.